### PR TITLE
Replaced index imports with direct ones

### DIFF
--- a/projects/schema-form/src/lib/form.component.ts
+++ b/projects/schema-form/src/lib/form.component.ts
@@ -7,15 +7,13 @@ import {
   Output
 } from '@angular/core';
 
-import {
-  Action,
-  ActionRegistry,
-  FormPropertyFactory,
-  FormProperty,
-  SchemaPreprocessor,
-  ValidatorRegistry,
-  Validator
-} from './model';
+import {Action} from './model/action';
+import {ActionRegistry} from './model/actionregistry';
+import {FormProperty} from './model/formproperty';
+import {FormPropertyFactory} from './model/formpropertyfactory';
+import {SchemaPreprocessor} from './model/schemapreprocessor';
+import {ValidatorRegistry} from './model/validatorregistry';
+import {Validator} from './model/validator';
 
 import {SchemaValidatorFactory} from './schemavalidatorfactory';
 import {WidgetFactory} from './widgetfactory';
@@ -23,7 +21,7 @@ import {TerminatorService} from './terminator.service';
 
 export function useFactory(schemaValidatorFactory, validatorRegistry) {
   return new FormPropertyFactory(schemaValidatorFactory, validatorRegistry);
-};
+}
 
 @Component({
   selector: 'sf-form',

--- a/projects/schema-form/src/lib/formelement.component.ts
+++ b/projects/schema-form/src/lib/formelement.component.ts
@@ -10,10 +10,8 @@ import {
 
 import { Widget } from './widget';
 
-import {
-  ActionRegistry,
-  FormProperty
-} from './model';
+import {ActionRegistry} from './model/actionregistry';
+import {FormProperty} from './model/formproperty';
 
 @Component({
   selector: 'sf-form-element',

--- a/projects/schema-form/src/lib/schema-form.module.ts
+++ b/projects/schema-form/src/lib/schema-form.module.ts
@@ -8,27 +8,25 @@ import {
 import {FormElementComponent} from './formelement.component';
 import {FormComponent} from './form.component';
 import {WidgetChooserComponent} from './widgetchooser.component';
-import {
-  ArrayWidget,
-  ButtonWidget,
-  ObjectWidget,
-  CheckboxWidget,
-  FileWidget,
-  IntegerWidget,
-  TextAreaWidget,
-  RadioWidget,
-  RangeWidget,
-  SelectWidget,
-  StringWidget
-} from './defaultwidgets';
+import {ArrayWidget} from './defaultwidgets/array/array.widget';
+import {ButtonWidget} from './defaultwidgets/button/button.widget';
+import {ObjectWidget} from './defaultwidgets/object/object.widget';
+import {CheckboxWidget} from './defaultwidgets/checkbox/checkbox.widget';
+import {FileWidget} from './defaultwidgets/file/file.widget';
+import {IntegerWidget} from './defaultwidgets/integer/integer.widget';
+import {TextAreaWidget} from './defaultwidgets/textarea/textarea.widget';
+import {RadioWidget} from './defaultwidgets/radio/radio.widget';
+import {RangeWidget} from './defaultwidgets/range/range.widget';
+import {SelectWidget} from './defaultwidgets/select/select.widget';
+import {StringWidget} from './defaultwidgets/string/string.widget';
+import {DefaultWidgetRegistry} from './defaultwidgets/defaultwidgetregistry';
 import {
   DefaultWidget
 } from './default.widget';
 
 import {WidgetRegistry} from './widgetregistry';
-import {DefaultWidgetRegistry} from './defaultwidgets';
 import {SchemaValidatorFactory, ZSchemaValidatorFactory} from './schemavalidatorfactory';
-import {FormElementComponentAction} from "./formelement.action.component";
+import {FormElementComponentAction} from './formelement.action.component';
 
 const moduleProviders = [
   {

--- a/projects/schema-form/src/lib/widget.ts
+++ b/projects/schema-form/src/lib/widget.ts
@@ -1,6 +1,9 @@
 import {AfterViewInit} from '@angular/core';
 import {FormControl} from '@angular/forms';
-import {ArrayProperty, FormProperty, ObjectProperty} from './model';
+
+import {ArrayProperty} from './model/arrayproperty';
+import {FormProperty} from './model/formproperty';
+import {ObjectProperty} from './model/objectproperty';
 
 export abstract class Widget<T extends FormProperty> {
   formProperty: T;

--- a/projects/schema-form/src/public_api.ts
+++ b/projects/schema-form/src/public_api.ts
@@ -2,4 +2,37 @@
  * Public API Surface of schema-form
  */
 
-export * from './lib/index';
+// export * from './lib/index';
+export { FormComponent } from './lib/form.component';
+export { FormElementComponent } from './lib/formelement.component';
+export { FormElementComponentAction } from './lib/formelement.action.component';
+export { WidgetChooserComponent } from './lib/widgetchooser.component';
+export { WidgetRegistry } from './lib/widgetregistry';
+export { Validator } from './lib/model/validator';
+export {
+  SchemaValidatorFactory,
+  ZSchemaValidatorFactory
+} from './lib/schemavalidatorfactory';
+export {
+  Widget,
+  ControlWidget,
+  ArrayLayoutWidget,
+  ObjectLayoutWidget
+} from './lib/widget';
+
+export { ArrayWidget } from './lib/defaultwidgets/array/array.widget';
+export { ButtonWidget } from './lib/defaultwidgets/button/button.widget';
+export { ObjectWidget } from './lib/defaultwidgets/object/object.widget';
+export { CheckboxWidget } from './lib/defaultwidgets/checkbox/checkbox.widget';
+export { FileWidget } from './lib/defaultwidgets/file/file.widget';
+export { IntegerWidget } from './lib/defaultwidgets/integer/integer.widget';
+export { TextAreaWidget } from './lib/defaultwidgets/textarea/textarea.widget';
+export { RadioWidget } from './lib/defaultwidgets/radio/radio.widget';
+export { RangeWidget } from './lib/defaultwidgets/range/range.widget';
+export { SelectWidget } from './lib/defaultwidgets/select/select.widget';
+export { StringWidget } from './lib/defaultwidgets/string/string.widget';
+export {
+  DefaultWidgetRegistry
+} from './lib/defaultwidgets/defaultwidgetregistry';
+
+export { SchemaFormModule } from './lib/schema-form.module';


### PR DESCRIPTION
ng-packagr is having problems (dherges/ng-packagr#917 , angular/angular-cli#10967) with index imports inside the library after build. Importing directly from the definition is a workaround to the problem.

resolve #210.
