### PR TITLE
Add normalizeExtensions to SchemaPreprocessor

### DIFF
--- a/projects/schema-form/src/lib/model/schemapreprocessor.ts
+++ b/projects/schema-form/src/lib/model/schemapreprocessor.ts
@@ -169,7 +169,8 @@ export class SchemaPreprocessor {
       let k = keys[i];
       let e = extensions.find(e => !!k.match(e.regex));
       if (e) {
-        let copy = JSON.parse(JSON.stringify(e));
+        let v = schema[k];
+        let copy = JSON.parse(JSON.stringify(v));
         schema[e.name] = copy;
       }
     }

--- a/projects/schema-form/src/lib/model/schemapreprocessor.ts
+++ b/projects/schema-form/src/lib/model/schemapreprocessor.ts
@@ -18,6 +18,7 @@ export class SchemaPreprocessor {
 
   static preprocess(jsonSchema: any, path = '/'): any {
     jsonSchema = jsonSchema || {};
+    SchemaPreprocessor.normalizeExtensions(jsonSchema);
     if (jsonSchema.type === 'object') {
       SchemaPreprocessor.checkProperties(jsonSchema, path);
       SchemaPreprocessor.checkAndCreateFieldsets(jsonSchema, path);
@@ -145,6 +146,31 @@ export class SchemaPreprocessor {
             SchemaPreprocessor.removeRecursiveRefProperties(jsonSchema.properties[fieldId], definitionPath);
           }
         }
+      }
+    }
+  }
+  
+  /**
+   * Enables alias names for JSON schema extensions.
+   *
+   * Copies the value of each alias JSON schema property
+   * to the JSON schema property of ngx-schema-form.
+   *
+   * @param schema JSON schema to enable alias names.
+   */
+  private static normalizeExtensions(schema: any): void {
+    const extensions = [
+        { name: "fieldsets", regex: /^x-?field-?sets$/i },
+        { name: "widget",    regex: /^x-?widget$/i },
+        { name: "visibleIf", regex: /^x-?visible-?if$/i }
+    ];
+    const keys = Object.keys(schema);
+    for (let i = 0; i < keys.length; ++i) {
+      let k = keys[i];
+      let e = extensions.find(e => !!k.match(e.regex));
+      if (e) {
+        let copy = JSON.parse(JSON.stringify(e));
+        schema[e.name] = copy;
       }
     }
   }


### PR DESCRIPTION
This pull request allows flexible alternate names for the three known JSON schema extensions of `ngx-schema-form`.

| Name | Regular Expression | Examples
| ---- | ---- | ---- |
| fieldsets  | `/^x-?field-?sets$/i` | `X-Field-Sets`, `x-fieldsets`, `xFieldSets` |
| widget | `/^x-?widget$/i` | `X-Widget`, `x-widget`, `xWidget` |
| visibleIf | `/^x-?visible-?if$/i` | `X-Visible-If`, `x-visbleif`, `xVisibleIf` |

----

I tested...

```
function normalizeExtensions(schema) {
    const extensions = [
        { name: "fieldsets", regex: /^x-?field-?sets$/i },
        { name: "widget",    regex: /^x-?widget$/i },
        { name: "visibleIf", regex: /^x-?visible-?if$/i }
    ];
    const keys = Object.keys(schema);
    for (let i = 0; i < keys.length; ++i) {
      let k = keys[i];
      let e = extensions.find(e => !!k.match(e.regex));
      if (e) {
        let v = schema[k];
        let copy = JSON.parse(JSON.stringify(v));
        schema[e.name] = copy;
      }
    }
}
```

... in the browser and it seems to work:

```
$ npm test

  0% compiling(node:19920) DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead
13 07 2018 19:03:20.590:INFO [karma]: Karma v1.7.1 server started at http://0.0.0.0:9876/
13 07 2018 19:03:20.591:INFO [launcher]: Launching browser Chrome with unlimited concurrency
13 07 2018 19:03:20.594:INFO [launcher]: Starting browser Chrome
13 07 2018 19:03:26.005:INFO [Chrome 57.0.2987 (Linux 0.0.0)]: Connected on socket MSQ7v8twB1KecoA1AAAA with id 65955075
Chrome 57.0.2987 (Linux 0.0.0): Executed 43 of 44 (skipped 1) SUCCESS (4.591 secs / 4.546 secs)
```