### PR TITLE
add Action, ActionRegistry and ValidatorRegistry to public api - fixes #228

### DIFF
--- a/projects/schema-form/src/lib/index.ts
+++ b/projects/schema-form/src/lib/index.ts
@@ -4,6 +4,9 @@ export { FormElementComponentAction } from './formelement.action.component';
 export { WidgetChooserComponent } from './widgetchooser.component';
 export { WidgetRegistry } from './widgetregistry';
 export { Validator } from './model/validator';
+export { ValidatorRegistry } from './model/validatorregistry';
+export { Action } from './model/action';
+export { ActionRegistry } from './model/actionregistry';
 export { SchemaValidatorFactory, ZSchemaValidatorFactory } from './schemavalidatorfactory';
 export {
     Widget,

--- a/projects/schema-form/src/public_api.ts
+++ b/projects/schema-form/src/public_api.ts
@@ -9,6 +9,9 @@ export { FormElementComponentAction } from './lib/formelement.action.component';
 export { WidgetChooserComponent } from './lib/widgetchooser.component';
 export { WidgetRegistry } from './lib/widgetregistry';
 export { Validator } from './lib/model/validator';
+export { ValidatorRegistry } from './lib/model/validatorregistry';
+export { Action } from './lib/model/action';
+export { ActionRegistry } from './lib/model/actionregistry';
 export {
   SchemaValidatorFactory,
   ZSchemaValidatorFactory


### PR DESCRIPTION
add Action, ActionRegistry and ValidatorRegistry to public api


I would recommend to extend the public API with the classes `Action`, `ActionRegistry` and `ValidatorRegistry`.

I've the case where it is required to execute an action from action-registry even if it is not bound to any button.

```
            const action: Action = this.actionRegistry.get(actionId)
            if (action) {
                action(this.formProperty, params)
            }
```
The same for validator-registry.



_would be happy to see this coming :-)_