### PR TITLE
add json schema declaring schema-form specific properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,22 @@ npm install ngx-schema-form --save
 
 You just have to check that all the peer-dependencies of this module are satisfied in your package.json.
 
+##### JSON Schema
+With the installation there comes a JSON-Schema file that declares all specific or additional
+properties supported by *ngx-schema-form*.
+
+When using `*.json` files you may declare it with the `$schema` property to let your IDE's autocompletion help you create a schema-form.
+
+```bash
+{
+  "$schema": "./node_modules/ngx-schema-form/ngx-schema-form-schema.json",
+  "title": "My awesome schema-form"
+  ...
+}
+
+```
+
+
 ## Getting started
 Here our goal will be to create a simple login form.
 Let's start by creating a simple AppComponent taking a simple JSON schema as input.
@@ -800,7 +816,7 @@ If you want to work with the demo:
 
 ```bash
 npm install -g @angular/cli
-npm innstall
+npm install
 ng build schema-from
 npm start
 ```

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
+    "copy:schema": "node -e \"var src='./schema/ngx-schema-form-schema.json'; var dest='./dist/schema-form/ngx-schema-form-schema.json'; var fs = require('fs'); if (fs.existsSync(src)) { var data = fs.readFileSync(src, 'utf-8'); fs.writeFileSync(dest, data);}\"",
+    "build:lib": "ng build --prod schema-form && npm run copy:schema",
     "build-demo": "ng build --prod --base-href /ngx-schema-form/dist/ngx-schema-form/",
     "test": "ng test schema-form --watch=false",
     "lint": "ng lint"

--- a/schema/ngx-schema-form-schema.json
+++ b/schema/ngx-schema-form-schema.json
@@ -1,0 +1,271 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "https://ngx-schema-form/schema",
+  "title": "JSON Schema ngx-schema-form",
+  "type": "object",
+  "$ref": "#/definitions/formWidgetType",
+  "allOf": [
+    {
+      "$ref": "http://json-schema.org/draft-07/schema#"
+    }
+  ],
+  "definitions": {
+    "widgetTypeCustom": {
+      "type": "string",
+      "description": "The name of custom widget type to use"
+    },
+    "widgetTypeSimple": {
+      "type": "string",
+      "description": "The name of widget type to use",
+      "enum": [
+        "array",
+        "object",
+        "string",
+        "search",
+        "tel",
+        "url",
+        "email",
+        "password",
+        "color",
+        "date",
+        "date-time",
+        "time",
+        "integer",
+        "number",
+        "range",
+        "textarea",
+        "file",
+        "select",
+        "radio",
+        "boolean",
+        "checkbox",
+        "button",
+        "hidden"
+      ]
+    },
+    "widgetType": {
+      "type": "object",
+      "description": "The widget type to use.",
+      "properties": {
+        "id": {
+          "description": "The id of the widget.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/widgetTypeSimple"
+            },
+            {
+              "$ref": "#/definitions/widgetTypeCustom"
+            }
+          ]
+        },
+        "buttons": {
+          "$ref": "#/definitions/buttonArrayType"
+        },
+        "oneOf": {
+          "type": "array",
+          "description": "Defines a collection to use for selectable widgets (SELECT, RADIO ...).",
+          "items": {
+            "properties": {
+              "enum": {
+                "type": "array",
+                "items": {
+                  "oneOf": [
+                    {
+                      "type": "string",
+                      "description": "Any string value."
+                    },
+                    {
+                      "type": "boolean",
+                      "description": "Either true or false."
+                    },
+                    {
+                      "type": "number",
+                      "description": "Any number value."
+                    },
+                    {
+                      "type": "null",
+                      "description": "Null value."
+                    }
+                  ]
+                },
+                "minItems": 1,
+                "uniqueItems": true,
+                "description": "The value of this item in the selection. Only the first item will be used as value. Any value except object is allowed."
+              },
+              "description": {
+                "type": "string",
+                "description": "The label of this item in the selection."
+              }
+            }
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "buttonType": {
+      "description": "A list of buttons to trigger some action for this field.",
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string",
+          "description": "The label to show on the button."
+        },
+        "id": {
+          "type": "string",
+          "description": "The action id must match action defined in the action object."
+        },
+        "parameters": {
+          "type": "object",
+          "description": "Custom defined properties that will be passed to the action method."
+        },
+        "widget": {
+          "$ref": "#/definitions/widgetTypeCustom",
+          "description": "Custom defined widget id, that will do the rendering of this button. Will render a default button if not set."
+        }
+      },
+      "required": [
+        "id",
+        "label"
+      ],
+      "additionalProperties": true
+    },
+    "buttonArrayType": {
+      "description": "A list of buttons to trigger some action for this field.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/buttonType"
+      },
+      "uniqueItems": true,
+      "default": [],
+      "minItems": 1
+    },
+    "fieldsArrayType": {
+      "description": "A list of field paths.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true,
+      "default": []
+    },
+    "fieldsetsType": {
+      "description": "A section of fields.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The section id."
+        },
+        "title": {
+          "type": "string",
+          "description": "The label of the section."
+        },
+        "fields": {
+          "description": "A list of property keys representing fields that belong to this sections.",
+          "$ref": "#/definitions/fieldsArrayType"
+        }
+      },
+      "required": [
+        "id",
+        "fields"
+      ],
+      "additionalProperties": true
+    },
+    "fieldsetsArrayType": {
+      "description": "A list of definitions representing sections of widgets.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/fieldsetsType"
+      },
+      "uniqueItems": true,
+      "default": [],
+      "minItems": 1
+    },
+    "formWidgetTypeProperties": {
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "The form title of the root form. Will only be showed when is an inline form"
+        },
+        "widget": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/widgetTypeSimple"
+            },
+            {
+              "$ref": "#/definitions/widgetType"
+            },
+            {
+              "$ref": "#/definitions/widgetTypeCustom"
+            }
+          ]
+        },
+        "order": {
+          "description": "A list of unique property keys describing the final order.",
+          "$ref": "#/definitions/fieldsArrayType"
+        },
+        "fieldsets": {
+          "$ref": "#/definitions/fieldsetsArrayType"
+        },
+        "buttons": {
+          "$ref": "#/definitions/buttonArrayType"
+        },
+        "placeholder": {
+          "type": "string",
+          "description": "A placeholder to pre-fill input field. Will work with any HTML element of type input."
+        },
+        "visibleIf": {
+          "type": "object",
+          "description": "Definition of when is this widget visible or not. The schema property path of target fields is expected to be separated by '/' and not by '.'. E.g. '/myform/myfield'",
+          "patternProperties": {
+            "^.*$": {
+              "description": "The path to any other property. E.g: /cat/name",
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "$ANY$"
+                    ],
+                    "description": "When the field has any values set."
+                  },
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "properties": {
+          "patternProperties": {
+            "^.*$": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/formWidgetTypeProperties"
+                },
+                {
+                  "$ref": "http://json-schema.org/draft-07/schema#"
+                }
+              ]
+            }
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "formWidgetType": {
+      "$ref": "#/definitions/formWidgetTypeProperties",
+      "type": "object",
+      "description": "A form widget.",
+      "additionalProperties": true
+    }
+  }
+}


### PR DESCRIPTION
I'd like to share this JSON Schema file that helps me a lot.

It is just a handy helper  for your IDE when creating schema forms.

Simply set it in the`$schema` property in the `.json` file and the IDE's autocompletion does the rest.

Here a GIF image that shows what it looks like with IntelliJ:

![json-schema-autocomplete](https://user-images.githubusercontent.com/2026072/45928129-f0956400-bf3e-11e8-90dc-f1f6bf34641b.gif)


If there is a chance to get this schema on a public domain, this would be also a greater benefit.

Any way I would love to see this coming.